### PR TITLE
Adds OAuth failure callback

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -163,5 +163,10 @@ Cuba.define do
 
       res.redirect "/dashboard"
     end
+
+    on "auth/failure" do
+      flash[:error] = I18n.t(".errors.login_error")
+      res.redirect "/"
+    end
   end
 end

--- a/locale/en/application.yml
+++ b/locale/en/application.yml
@@ -44,3 +44,4 @@ en:
   errors:
     not_found: Page not found (404)
     not_found_description: The page you are looking for does not exist.
+    login_error: There has been an error on your login. Please try again.

--- a/locale/es/application.yml
+++ b/locale/es/application.yml
@@ -44,3 +44,4 @@ es:
   errors:
     not_found: La página no fue encontrada (404)
     not_found_description: La página que estás buscando no ha sido encontrada.
+    login_error: Hubo un error en su ingreso. Por favor, intente nuevamente.


### PR DESCRIPTION
This PR adds a simple URL for a callback on authentication failure. It adds a simple error message and redirects to homepage.

If you want to try it locally, you need to add the code below before the configuration of OmniAuth in app.rb, otherwise OmniAuth will raise an exception in development mode and won't redirect to the callback

```
OmniAuth.config.on_failure = Proc.new { |env|
  OmniAuth::FailureEndpoint.new(env).redirect_to_failure
}
```
