### PR TITLE
Add user image to rank page

### DIFF
--- a/public/css/funky_world_cup.css
+++ b/public/css/funky_world_cup.css
@@ -243,6 +243,11 @@ html, body {
     min-width: 32px;
     text-align: center;
   }
+  .rank-box {
+    display: inline-block;
+    width: 45px;
+    text-align: right;
+  }
 
 #group-participants-list.by-owner {
   width: 90%;
@@ -375,6 +380,8 @@ footer {
   padding-left: 0px !important;
   padding-right: 25px !important;
 }
+
+
 
 /* responsive */
 @media (max-width: 479px) {

--- a/views/pages/rank.html.erb
+++ b/views/pages/rank.html.erb
@@ -7,9 +7,14 @@
     <ul class="list-group" id="rank-list">
       <% @rank.each_with_index do |rank, index| %>
       <li class="list-group-item" id="position-<%= index+1 %>">
-        <span class="badge"><%=rank.score || 0 %></span>
-        <span class="label label-<%= index < 3 ? 'success' : 'warning' %>">#<%= index + 1 %></span>
-        <span><%= rank.user.nickname %></span>
+          <span class="badge"><%=rank.score || 0 %></span>
+        <div class="rank-box">
+          <span class="label label-<%= index < 3 ? 'success' : 'warning' %>">#<%= index + 1 %></span>
+        </div>
+        <span>
+          <img src="<%= rank.user.image %>" class="participant-img">
+          <%= rank.user.nickname %>
+        </span>
       </li>
       <% end %>
     </ul>


### PR DESCRIPTION
This PR add user image to rank page. The new design allow up to 9999 users without braking.
![fwc_rank](https://cloud.githubusercontent.com/assets/357127/3143069/7ef6a1f8-e9e4-11e3-836f-ba920205adc0.png)
