### PR TITLE
97 bis new worker jobs format

### DIFF
--- a/bin/fwc-worker
+++ b/bin/fwc-worker
@@ -16,6 +16,21 @@ class FWCJob
 
   def start
     require @job_path
+    job_class = constantize(@name)
+
+    Signal.trap("INT")  { EventMachine.stop }
+    Signal.trap("TERM") { EventMachine.stop }
+
+    EventMachine.run do
+      timer = EventMachine::PeriodicTimer.new(job_class.interval || 60) do
+        LOGGER.info job_class.message
+        job_class.run
+        if job_class.one_run_only
+          timer.cancel
+          EventMachine.stop
+        end
+      end
+    end
   end
   
   def stop
@@ -37,6 +52,10 @@ class FWCJob
     if File.exists?(@pid_path)
       File.delete(@pid_path)
     end
+  end
+
+  def constantize(name)
+    eval name.split("_").push("job").map(&:capitalize).join
   end
 end
 

--- a/jobs/update_results.rb
+++ b/jobs/update_results.rb
@@ -6,8 +6,16 @@ require "./app"
 
 LOGGER= Logger.new('jobs/logs/update_results.log')
 
-module UpdateResultsJob
+class UpdateResultsJob < BaseJob
   RESULTS_URL = 'http://www.livescore.com/worldcup2014/'
+
+  def self.interval
+    ENV['UPDATE_RESULTS_INTERVAL'] || 300
+  end
+
+  def self.message
+    "Updating Results..."
+  end
 
   def self.run
     begin
@@ -65,16 +73,4 @@ module UpdateResultsJob
       end
     end
   end
-
 end
-
-Signal.trap("INT")  { EventMachine.stop }
-Signal.trap("TERM") { EventMachine.stop }
-
-EventMachine.run do
-  timer = EventMachine::PeriodicTimer.new(ENV['UPDATE_RESULTS_INTERVAL'] || 300) do
-    LOGGER.info "Updating Results..."
-    UpdateResultsJob.run
-  end
-end
-

--- a/lib/base_job.rb
+++ b/lib/base_job.rb
@@ -1,0 +1,17 @@
+class BaseJob
+  def self.message
+    "Running..."
+  end
+
+  def self.interval
+    raise RuntimeError.new("Must reimplement self.interval in a subclass")
+  end
+
+  def self.run
+    raise RuntimeError.new("Must reimplement self.interval in a subclass")
+  end
+
+  def self.one_run_only
+    false
+  end
+end

--- a/test/jobs/add_result_test.rb
+++ b/test/jobs/add_result_test.rb
@@ -21,9 +21,9 @@ describe "ResultsJob" do
 
     assert_equal nil, match.result
 
-    ENV['ADD_RESULT_ONE_RUN'] = "1"
-    ENV['ADD_RESULT_INTERVAL'] = "1"
     require_relative "../../jobs/add_result.rb"
+
+    AddResultJob.run
 
     match.reload
 
@@ -50,9 +50,9 @@ describe "ResultsJob" do
 
     assert_equal false, match.result.nil?
 
-    ENV['ADD_RESULT_ONE_RUN'] = "1"
-    ENV['ADD_RESULT_INTERVAL'] = "1"
     require_relative "../../jobs/add_result.rb"
+
+    AddResultJob.run
 
     assert_equal 1, Result.where(match_id: match.id).count
   end


### PR DESCRIPTION
**ATTENTION**
**This PR should be merged into #117 before that one is merged to master**
This PR proposes a new Job format, moving the EventMachine handling to the worker file.
To make this possible it assumes a convention within the job filename and the job class the file contains.
This adds decoupling and flexibility and get these things ready to be moved to a gem.
To help creating the jobs classes it adds a base class [BaseJob](https://github.com/threefunkymonkeys/funky-world-cup/blob/00fe4d74c3d51aecc520313e3e1e8370b5821a20/lib/base_job.rb) to provide a common interface to the jobs classes and complaining if you miss some data required by the worker at the moment of running the job.

So, long story short:
Your file `jobs/update_results.rb` needs to hold a class named `UpdateResultsJob`, which should inherit from `BaseJob`.
Your class `UpdateResultsJob` must reimplement `self.interval` and `self.run`, both self explanatory, and it also may reimplement `self.message` for the logging message when the job is run.
