### PR TITLE
Do not wrap lines in table for points and team name

### DIFF
--- a/public/css/funky_world_cup.css
+++ b/public/css/funky_world_cup.css
@@ -135,7 +135,12 @@ html, body {
     .matches-table td .status {
       vertical-align: top;
     }
-  
+
+    .matches-table td span.text-danger {
+        white-space: nowrap;
+    }
+
+
   .matches-table tr.mobile-info {
     display: none;
   }
@@ -161,6 +166,7 @@ html, body {
       padding: 0 5px;
       text-transform: uppercase;
       line-height: 16px;
+      white-space: nowrap;
     }
     .matches-table.small-table td .time {
       font-size: 0.7em;


### PR DESCRIPTION
This fixes some columns whose team names or points are broken into two different lines (particularly all the rows with South Corea in its name.) Now everything looks super tidy and beautiful.
