### PR TITLE
Fix predict modal

### DIFF
--- a/assets/sass/funky_world_cup.scss
+++ b/assets/sass/funky_world_cup.scss
@@ -71,6 +71,7 @@
 @import "lbd/partial-nucleo-icons";
 
 // FWC Specific styles
+@import "funky_world_cup/main";
 @import "funky_world_cup/navigation";
 @import "funky_world_cup/fixture_tables";
 @import "funky_world_cup/positions_tables";

--- a/assets/sass/funky_world_cup/_fixture_tables.scss
+++ b/assets/sass/funky_world_cup/_fixture_tables.scss
@@ -4,11 +4,6 @@
   td.team-column {
     width: 20%;
     text-align: center;
-
-    img.flag {
-      width: 70px;
-      height: auto;
-    }
   }
 
   .team-column-groups {

--- a/assets/sass/funky_world_cup/_main.scss
+++ b/assets/sass/funky_world_cup/_main.scss
@@ -1,0 +1,31 @@
+$modal-border-color: #e9ecef;
+
+img.flag {
+  width: 70px;
+  height: auto;
+}
+
+.modal-header {
+  border-bottom: 1px solid $modal-border-color;
+
+  .modal-title {
+    margin-top: 0px !important;
+  }
+}
+
+.modal-footer {
+  border-top: 1px solid $modal-border-color;
+}
+
+.predict {
+  input[type=text].form-control {
+    text-align: center;
+  }
+
+  .matches-table {
+    .predict-host, .predict-rival {
+      text-align: center;
+      width: 35%;
+    }
+  }
+}

--- a/locale/en/matches.yml
+++ b/locale/en/matches.yml
@@ -1,6 +1,6 @@
 en:
   matches:
-    predict_title: Predict the result
+    predict_title: Enter your prediction
     warning_title: Warning
     warning_text: Wait! Check your prediction twice! Once confirmed you will not be able to change it.
     penalties: Penalties

--- a/public/js/funky_world_cup.js
+++ b/public/js/funky_world_cup.js
@@ -167,8 +167,8 @@ body.on('click', ".btn-predict", function(event) {
   });
 
   if(penalties) {
-    modal.find(".modal-penalties").show()
-    modal.find(".alert-penalties").show()
+    modal.find(".modal-penalties").show();
+    modal.find(".alert-penalties").show();
   }
 
   modal.modal('show');

--- a/public/js/funky_world_cup.js
+++ b/public/js/funky_world_cup.js
@@ -150,6 +150,7 @@ body.on('click', ".btn-predict", function(event) {
       penalties  = _this.attr("data-penalties") === "true";
 
   var modal = $("#modal-predict");
+  modal.find(".alert-penalties").hide();
 
   modal.find("#match-id").val(match_id);
   modal.find("input[type=\"text\"]").val(0);

--- a/public/js/funky_world_cup.js
+++ b/public/js/funky_world_cup.js
@@ -154,22 +154,18 @@ body.on('click', ".btn-predict", function(event) {
   modal.find("#match-id").val(match_id);
   modal.find("input[type=\"text\"]").val(0);
 
-  var host_td = modal.find("td.modal-host");
-  host_td.html($("<img>").attr("src", "/img/flags/" + host_flag))
-         .append($("<br>"))
-         .append($("<span>").addClass("team").text(host_name));
+  var host_td = modal.find("td.predict-host");
+  host_td.html($("<img class='flag'>").attr("src", "/img/flags/" + host_flag));
 
-  var rival_td = modal.find("td.modal-rival");
-  rival_td.html($("<img>").attr("src", "/img/flags/" + rival_flag))
-         .append($("<br>"))
-         .append($("<span>").addClass("team").text(rival_name));
+  var rival_td = modal.find("td.predict-rival");
+  rival_td.html($("<img class='flag'>").attr("src", "/img/flags/" + rival_flag));
 
   modal.on('click', "input[type=\"text\"]", function(evt) {
     evt.preventDefault();
     evt.stopPropagation();
     $(this).select();
   });
-  
+
   if(penalties) {
     modal.find(".modal-penalties").show()
     modal.find(".alert-penalties").show()
@@ -196,5 +192,3 @@ var anchor = window.location.hash
 if(anchor != "") {
   $(anchor).addClass("fwc-highlight");
 }
-
-$('.chosen-select').chosen();

--- a/views/layouts/application.html.erb
+++ b/views/layouts/application.html.erb
@@ -22,8 +22,6 @@
     <link href="/css/funky_world_cup.css?v=1.4.0" rel="stylesheet"/>
 
 
-    <%#<link rel="stylesheet" href="/css/funky_world_cup.css">%>
-
     <%= render("views/shared/_analytics.html.erb") %>
 
     <!--     Fonts and icons     -->

--- a/views/layouts/application.html.erb
+++ b/views/layouts/application.html.erb
@@ -87,6 +87,7 @@
 
   <script src="/js/light-bootstrap-dashboard.js?v=2.0.1" type="text/javascript"></script>
   <script src="/js/vue.js" type="text/javascript"></script>
+  <script src="/js/funky_world_cup.js" type="text/javascript"></script>
 
   <% yield_content :javascripts %>
 

--- a/views/shared/_match_row_small.html.erb
+++ b/views/shared/_match_row_small.html.erb
@@ -66,7 +66,7 @@
       <% end %>
     <% elsif match.predictable? %>
       <button type="button"
-              class="btn btn-info btn-sm"
+              class="btn btn-info btn-sm btn-predict"
               data-host="<%= I18n.t(".teams.#{match.host_team.iso_code}") %>"
               data-host-flag="<%= match.host_team.flag %>"
               data-rival="<%= I18n.t(".teams.#{match.rival_team.iso_code}") %>"

--- a/views/shared/_prediction_modal.html.erb
+++ b/views/shared/_prediction_modal.html.erb
@@ -1,35 +1,34 @@
-<div class="modal fade" id="modal-predict">
+<div class="modal fade predict" id="modal-predict">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close modal-close" data-dismiss="modal" aria-hidden="true">&times;</button>
         <h4 class="modal-title"><%= I18n.t('.matches.predict_title') %></h4>
       </div>
-      <div class="modal-body">
+      <div class="modal-body table-full-width table-responsiveel-dialog">
         <form method="post" action="/users/<%= current_user.id %>/predictions" id="prediction-form">
           <input type="hidden" name="match_id" id="match-id" value="">
           <% if defined?(redirect) %>
             <input type="hidden" name="back_to" value="<%= redirect %>">
           <% end %>
-          <table class="table table-striped table-hover matches-table">
+          <table class="table table-striped matches-table">
             <tbody>
               <tr>
-                <td class="modal-host"></td>
-                <td class="modal-host-score">
-                  <input type="text" class="input-lg" name="host_score">
+                <td class="predict-host"></td>
+                <td class="predict-host-score">
+                  <input type="text" class="form-control" name="host_score">
                 </td>
-                <td class="modal-rival-score">
-                  <input type="text" class="input-lg" name="rival_score">
+                <td class="predict-rival-score">
+                  <input type="text" class="form-control" name="rival_score">
                 </td>
-                <td class="modal-rival"></td>
+                <td class="predict-rival"></td>
               </tr>
               <tr style="display: none;" class="modal-penalties">
                 <td class=""><%= I18n.t('.matches.penalties')%></td>
                 <td class="modal-host-score">
-                  <input type="text" class="input-lg" name="host_penalties_score">
+                  <input type="text" class="form-control" name="host_penalties_score">
                 </td>
                 <td class="modal-rival-score">
-                  <input type="text" class="input-lg" name="rival_penalties_score">
+                  <input type="text" class="form-control" name="rival_penalties_score">
                 </td>
                 <td class="">
                   <a class="penalties-info" target="_blank" href="/rules#score"><span class="badge">?</span></a>
@@ -41,11 +40,14 @@
         <div class="alert-penalties alert alert-info" style="display:none">
           <p><%= I18n.t('.matches.penalties_text_html') %></p>
         </div>
-        
-        <div class="alert alert-warning">
-          <h4><%= I18n.t('.matches.warning_title') %>!</h4>
-          <p><%= I18n.t('.matches.warning_text') %></p>
+
+        <div class="col-12 alert alert-warning alert-with-icon" role="alert">
+          <span data-notify="icon" class="nc-icon nc-bell-55"></span>
+          <span data-notify="message">
+            <strong><%= I18n.t('.matches.warning_text') %></strong>
+          </span>
         </div>
+
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default modal-close" data-dismiss="modal"><%= I18n.t('.actions.cancel') %></button>

--- a/views/shared/_prediction_modal.html.erb
+++ b/views/shared/_prediction_modal.html.erb
@@ -23,22 +23,25 @@
                 <td class="predict-rival"></td>
               </tr>
               <tr style="display: none;" class="modal-penalties">
-                <td class=""><%= I18n.t('.matches.penalties')%></td>
+                <td class="text-center"><%= I18n.t('.matches.penalties')%></td>
                 <td class="modal-host-score">
                   <input type="text" class="form-control" name="host_penalties_score">
                 </td>
                 <td class="modal-rival-score">
                   <input type="text" class="form-control" name="rival_penalties_score">
                 </td>
-                <td class="">
+                <td class="text-center">
                   <a class="penalties-info" target="_blank" href="/rules#score"><span class="badge">?</span></a>
                 </td>
               </tr>
             </tbody>
           </table>
         </form>
-        <div class="alert-penalties alert alert-info" style="display:none">
-          <p><%= I18n.t('.matches.penalties_text_html') %></p>
+        <div class="alert-penalties col-12 alert alert-info alert-with-icon" role="alert" class="display:none;">
+          <span data-notify="icon" class="nc-icon nc-bell-55"></span>
+          <span data-notify="message">
+            <strong><%= I18n.t('.matches.penalties_text_html') %></strong>
+          </span>
         </div>
 
         <div class="col-12 alert alert-warning alert-with-icon" role="alert">


### PR DESCRIPTION
This PR implements new template's styles to the prediction modal.

As mentioned in the issue, I've now adjusted the markup for the penalties predictions and here it how it looks now with the latest changes:

![image](https://user-images.githubusercontent.com/43977/39095182-cb662214-4612-11e8-8f12-f700bbc8cce9.png)


Closes #178