### PR TITLE
Implement template in ranking

### DIFF
--- a/assets/sass/funky_world_cup/_main.scss
+++ b/assets/sass/funky_world_cup/_main.scss
@@ -29,3 +29,8 @@ img.flag {
     }
   }
 }
+
+.share-icon {
+  display: inline-block;
+  width: 38%;
+}

--- a/assets/sass/funky_world_cup/_main.scss
+++ b/assets/sass/funky_world_cup/_main.scss
@@ -30,7 +30,7 @@ img.flag {
   }
 }
 
-.share-icon {
-  display: inline-block;
-  width: 38%;
+.link {
+  cursor: pointer;
+  @extend a
 }

--- a/assets/sass/funky_world_cup/_positions_tables.scss
+++ b/assets/sass/funky_world_cup/_positions_tables.scss
@@ -5,5 +5,15 @@
         display: table-cell;
       }
     }
+
+    &.rank-table {
+      tbody td:last-child {
+        display: table-cell;
+      }
+
+      tbody td:first-child {
+        width: 3rem;
+      }
+    }
   }
 }

--- a/locale/en/ranking.yml
+++ b/locale/en/ranking.yml
@@ -1,0 +1,5 @@
+en:
+  ranking:
+    title: You have a score of %{score} and your current rank is %{rank}
+    subtitle: Check out %{groups} or <span id="open-share-modal" class="link">share</span> Funky World Cup!
+

--- a/locale/es/ranking.yml
+++ b/locale/es/ranking.yml
@@ -1,0 +1,5 @@
+es:
+  ranking:
+    title: Tenés un puntaje de %{score} y tu ranking actual es %{rank}
+    subtitle: Mirá %{groups} o <span id="open-share-modal" class="link">compartí</span> Funky World Cup!
+

--- a/public/js/funky_world_cup.js
+++ b/public/js/funky_world_cup.js
@@ -3,7 +3,7 @@ body = $("body")
 body.on('click', '#edit-prize-btn', function(event) {
   event.preventDefault();
   event.stopPropagation();
-  
+
   $("#prize-form").submit();
 });
 
@@ -15,14 +15,14 @@ body.on('click', '#new-prize-btn', function(event) {
       prize = input.val(),
       list = $("#prizes-list"),
       new_prize;
-  
+
   _this.parent().removeClass('has-error');
 
   if(prize.trim() == "") {
     _this.parent().addClass('has-error');
     return;
   }
-  
+
   $("#no-prize").hide();
   $("#edit-prize-btn").removeClass("hide")
   new_prize = $("<li>").addClass("list-group-item")
@@ -36,7 +36,7 @@ body.on('click', '#new-prize-btn', function(event) {
   list.append(new_prize);
 
   input.val("");
-  
+
   window.update_prizes_list();
 });
 
@@ -184,6 +184,13 @@ body.on('click', "#modal-predict #submit-prediction", function(event) {
 
 body.on('change', "#teams-filter", function(event){
   window.location = "/teams/" + event.target.value;
+});
+
+body.on('click', "#open-share-modal", function(event) {
+  event.preventDefault();
+  event.stopPropagation();
+
+  $("#modal-share").modal('show');
 });
 
 // Anchor highlight

--- a/routes/main.rb
+++ b/routes/main.rb
@@ -81,9 +81,7 @@ module FunkyWorldCup
               @rank[key] << rank
             end
 
-            res.write render("./views/layouts/application.html.erb") {
-              render("./views/pages/rank.html.erb")
-            }
+            res.write view("pages/rank.html")
           end
 
           not_found!

--- a/views/pages/rank.html.erb
+++ b/views/pages/rank.html.erb
@@ -1,32 +1,47 @@
-<h2>Rank</h2>
-<div class="panel panel-success">
-  <div class="panel-heading">
-    <h3 class="panel-title"></h3>
+<% content_for(:title){ I18n.t('.menu.rank')} %>
+
+<div class="card">
+  <div class="card-header">
+    <h4 class="card-title">
+      You have a score of <%= current_user.score %> and your current rank is <a href="#position-<%= @user_rank %>"><%= @user_rank %></a>
+      <a href="#" class="share-icon text-right"><i class="nc-icon nc-send"></i></a>
+    </h4>
   </div>
-  <div class="panel-body">
-    <ul class="list-group" id="rank-list">
-      <% @rank.each do |key, rank_for_key| %>
-        <% rank_for_key.each do |rank| %>
-        <li class="list-group-item" id="position-<%= key %>">
-            <span class="badge"><%=rank.score || 0 %></span>
-          <div class="rank-box">
-            <span class="label label-<%= key < 3 ? 'success' : 'warning' %>">#<%= key %></span>
-          </div>
-          <span>
-            <% if FunkyWorldCup.finalized? %>
-              <a href="/users/<%= rank.user.id %>/predictions">
-                <img src="<%= rank.user.image %>" class="participant-img">
-                <%= rank.user.nickname %>
-              </a>
-            <% else %>
-              <img src="<%= rank.user.image %>" class="participant-img">
-              <%= rank.user.nickname %>
+  <div class="card-body">
+    <div class="table-full-width table-responsive">
+      <table class="table rank-table">
+        <thead>
+          <tr>
+            <th>Position</th>
+            <th>Name</th>
+            <th class="text-center">Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @rank.each do |key, rank_for_key| %>
+            <% rank_for_key.each do |rank| %>
+              <tr id="position-<%= key %>">
+                <td><span class="label alert alert-<%= key < 3 ? 'success' : 'warning' %>">#<%= key %></span></td>
+                <td>
+                  <% if FunkyWorldCup.finalized? %>
+                    <a href="/users/<%= rank.user.id %>/predictions">
+                      <img src="<%= rank.user.image %>" class="participant-img d-none d-sm-inline d-md-inline">
+                      <%= rank.user.nickname %>
+                    </a>
+                  <% else %>
+                    <img src="<%= rank.user.image %>" class="participant-img d-none d-sm-inline d-md-inline">
+                    <%= rank.user.nickname %>
+                  <% end %>
+                </td>
+                <td class="text-center">
+                  <span class="label alert alert-info"><%=rank.score || 0 %></span>
+                </td>
+              </tr>
             <% end %>
-          </span>
-        </li>
-        <% end %>
-      <% end %>
-    </ul>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 

--- a/views/pages/rank.html.erb
+++ b/views/pages/rank.html.erb
@@ -1,11 +1,17 @@
 <% content_for(:title){ I18n.t('.menu.rank')} %>
 
+<%= partial("shared/_share_modal.html") %>
+
 <div class="card">
   <div class="card-header">
     <h4 class="card-title">
-      You have a score of <%= current_user.score %> and your current rank is <a href="#position-<%= @user_rank %>"><%= @user_rank %></a>
-      <a href="#" class="share-icon text-right"><i class="nc-icon nc-send"></i></a>
+      <% rank_link = "<a href='#position-%s'>%s</a>" % [@user_rank, @user_rank] %>
+      <%= I18n.t('.ranking.title', score: current_user.score, rank: rank_link) %>
     </h4>
+    <p class="card-category">
+    <% groups_link = "<a href='/groups'>%s</a>" % I18n.t('.menu.your_groups').downcase %>
+    <%= I18n.t('.ranking.subtitle', groups: groups_link) %>
+    </p>
   </div>
   <div class="card-body">
     <div class="table-full-width table-responsive">
@@ -44,4 +50,15 @@
     </div>
   </div>
 </div>
+<div id="fb-root"></div>
 
+<% content_for(:javascripts) do %>
+    <script>(function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s); js.id = id;
+      js.src = "//connect.facebook.net/<%= session[:locale] == :en ? 'en_US' : 'es_ES' %>/sdk.js#xfbml=1&appId=<%= ENV['FACEBOOK_APP_ID'] %>&version=v2.0";
+      fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));</script>
+    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+<% end %>

--- a/views/shared/_left_sidebar.html.erb
+++ b/views/shared/_left_sidebar.html.erb
@@ -40,6 +40,12 @@
           <p><%= I18n.t('.menu.positions') %></p>
         </a>
       </li>
+      <li class="nav-item <%= class_for_path("/rank") %>">
+        <a class="nav-link" href="/rank">
+          <i class="nc-icon nc-notes"></i>
+          <p><%= I18n.t('.menu.rank') %></p>
+        </a>
+      </li>
       <li class="nav-item <%= class_for_path("/groups") %>">
         <a class="nav-link" href="/groups">
           <i class="nc-icon nc-preferences-circle-rotate"></i>

--- a/views/shared/_share_modal.html.erb
+++ b/views/shared/_share_modal.html.erb
@@ -1,0 +1,38 @@
+<div class="modal fade" tabindex="-1" role="dialog" id="modal-share">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title"><%= I18n.t('.sidebar.share') %></h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <table class="table">
+          <tr>
+            <td class="w-50 text-center">
+              <a href="#" class="">
+                <a href="https://twitter.com/funkyworldcup" class="twitter-follow-button btn btn-social btn-twitter" data-show-count="false" data-size="large" data-lang="<%= session[:locale] %>">
+                  <i class="fa fa-twitter"></i>
+                  Follow @funkyworldcup</a>
+            </td>
+            <td class="w-50 text-center">
+              <a href="https://twitter.com/share" class="twitter-share-button btn btn-social btn-twitter" data-url="http://funkyworldcup.com/" data-via="funkyworldcup" data-lang="<%= session[:locale] %>" data-size="large" data-related="funkyworldcup" data-hashtags="<%= I18n.t(".sidebar.tweet_hashtag") %>" data-text="<%= I18n.t(".sidebar.tweet") %>">
+                <i class="fa fa-twitter"></i>
+                Twittear</a>
+            </td>
+          </tr>
+          <tr>
+            <td class="w-50 text-center">
+              <div class="fb-like" data-href="http://funkyworldcup.com/" data-layout="button_count" data-action="like" data-show-faces="false" data-share="false" data-size="large"></div>
+            </td>
+            <td class="w-50 text-center">
+              <div class="fb-share-button" data-href="http://funkyworldcup.com/" data-type="button_count" data-size="large"></div>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+


### PR DESCRIPTION
This PR implements the template styling in the ranking page.
As part of the work here, the share box that used to be in the right sidebar is moved to a modal window.

In the screenshots here, some images are not shown (including one of the Twitter buttons) due to APIs throttling after many page reloads when implementing the template.


![image](https://user-images.githubusercontent.com/43977/39667198-e99fe89a-5086-11e8-88db-1188be9665b2.png)

![image](https://user-images.githubusercontent.com/43977/39667215-2ad0e468-5087-11e8-9388-316317300330.png)
