### PR TITLE
Add predict modal partial in dashboard

### DIFF
--- a/views/pages/dashboard.html.erb
+++ b/views/pages/dashboard.html.erb
@@ -59,3 +59,4 @@
     </div>
   </div>
 </div>
+<%= render("views/shared/_prediction_modal.html.erb", id: current_user.id, redirect: 'cup-groups/fixture') %>


### PR DESCRIPTION
This PR fixes the predict modal bug in the dashboard.

![image](https://user-images.githubusercontent.com/43977/39667547-4fc0e3f6-508f-11e8-8ea8-c2b8a0aee7f4.png)

Closes #197 