### PR TITLE
Ranking page tweaks

### DIFF
--- a/routes/main.rb
+++ b/routes/main.rb
@@ -64,10 +64,11 @@ module FunkyWorldCup
           end
 
           on "rank" do
-            raw_rank = UserScore.order(Sequel.desc(:score), :id).all
-            key = 0
-            score = 0
-            @rank = Hash.new
+            @user_rank ||= UserScore.rank_for(current_user.id)
+            raw_rank   = UserScore.order(Sequel.desc(:score), :id).all
+            key        = 0
+            score      = 0
+            @rank      = Hash.new
 
             raw_rank.each do |rank|
               if score.zero? || score > rank.score

--- a/views/pages/rank.html.erb
+++ b/views/pages/rank.html.erb
@@ -26,7 +26,7 @@
         <tbody>
           <% @rank.each do |key, rank_for_key| %>
             <% rank_for_key.each do |rank| %>
-              <tr id="position-<%= key %>">
+              <tr id="position-<%= key %>" <%= rank.user.id == current_user.id ? 'class="alert-warning"' : '' %>>
                 <td><span class="label alert alert-<%= key < 3 ? 'success' : 'warning' %>">#<%= key %></span></td>
                 <td>
                   <% if FunkyWorldCup.finalized? %>

--- a/views/pages/rank.html.erb
+++ b/views/pages/rank.html.erb
@@ -2,7 +2,7 @@
 
 <%= partial("shared/_share_modal.html") %>
 
-<div class="card">
+<div class="card col-8 ml-auto mr-auto">
   <div class="card-header">
     <h4 class="card-title">
       <% rank_link = "<a href='#position-%s'>%s</a>" % [@user_rank, @user_rank] %>


### PR DESCRIPTION
This PR addresses issues #203, #208 and #209 by centering the ranking table in the page, showing the user's rank and highlighting the user position in the table.

![image](https://user-images.githubusercontent.com/43977/39959168-4cf63e0a-55e4-11e8-958a-c203d99459f3.png)

![image](https://user-images.githubusercontent.com/43977/39959181-90486796-55e4-11e8-99b0-84234cc9523b.png)

Close #203 
Close #208 
Close #209