### PR TITLE
Update minimum gem versions to work with ruby 2.5.1

### DIFF
--- a/.gems
+++ b/.gems
@@ -1,7 +1,7 @@
 cuba -v 3.1.1
 tilt -v 2.0.1
-sequel -v 4.9.0
-pg -v 0.17.1
+sequel -v 5.0.8
+pg -v 1.0.0
 omniauth-twitter -v 1.4.0
 omniauth-facebook -v 5.0.0
 rack-protection -v 1.5.3
@@ -12,3 +12,4 @@ clap -v 1.0.0
 eventmachine -v 1.2.5
 simple_oauth -v 0.2.0
 sass -v 3.5.5
+postmark -v 1.11.0

--- a/lib/funky_world_cup.rb
+++ b/lib/funky_world_cup.rb
@@ -21,6 +21,7 @@ module FunkyWorldCupApp
 
   class Database
     def self.connect(settings)
+      Sequel::Model.plugin :def_dataset_method
       Sequel.postgres settings
     end
   end


### PR DESCRIPTION
This PR updates the minimum gems for the app to work with Ruby 2.5.1.

I had to debug for a while on the server before I could make it work.
At least it's up and running now, we can upgrade the rest of the gems later.

@tarolandia please try it locally before approving, since I've done many things today and I wouldn't trust my mind at this point, I'm not sure if I'm missing something in the PR.

Thank you!