### PR TITLE
Enforce number inputs for predictions

### DIFF
--- a/views/shared/_prediction_modal.html.erb
+++ b/views/shared/_prediction_modal.html.erb
@@ -16,10 +16,10 @@
               <tr>
                 <td class="predict-host"></td>
                 <td class="predict-host-score">
-                  <input type="text" class="form-control" name="host_score">
+                  <input type="number" step="1" min="0" class="form-control" name="host_score">
                 </td>
                 <td class="predict-rival-score">
-                  <input type="text" class="form-control" name="rival_score">
+                  <input type="number" step="1" min="0" class="form-control" name="rival_score">
                 </td>
                 <td class="predict-rival"></td>
               </tr>


### PR DESCRIPTION
This PR enforces numeric inputs in the predictions modal, with a minimum valid value of `0`.

On server side, it's currently converting the parameters to integers, if a text type is somehow forced it will be turned to `0`.

I think it's enough for now.

Close #226 