### PR TITLE
Add deployment files

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,21 @@
+FROM ruby:2.5.1-alpine3.7
+
+# From LFHS http://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#srvDataForServicesProvidedBySystem
+RUN apk --no-cache add make gcc libc-dev g++ ncurses postgresql-dev libffi-dev
+
+ENV PATH /usr/local/bundle/bin:$PATH
+
+ENV INSTALL_DIR /srv/http/funkyworldcup.com
+
+WORKDIR $INSTALL_DIR
+
+ADD . $INSTALL_DIR
+
+RUN gem install dep puma
+
+RUN dep install
+
+EXPOSE 8080
+
+# Run the API
+CMD puma -w 3 -e production -v -p 8585 --redirect-stdout log/production.access.log --redirect-stderr log/production.error.log

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -1,0 +1,21 @@
+FROM ruby:2.5.1-alpine3.7
+
+# From LFHS http://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#srvDataForServicesProvidedBySystem
+RUN apk --no-cache add make gcc libc-dev g++ ncurses postgresql-dev libffi-dev
+
+ENV PATH /usr/local/bundle/bin:$PATH
+
+ENV INSTALL_DIR /srv/http/funkyworldcup.com
+
+WORKDIR $INSTALL_DIR
+
+ADD . $INSTALL_DIR
+
+RUN gem install dep puma
+
+RUN dep install
+
+EXPOSE 8080
+
+# Run the API
+CMD puma -w 3 -e staging -v -p 8080 --redirect-stdout log/staging.access.log --redirect-stderr log/staging.error.log

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+
+require "yaml"
+
+settings = YAML.load_file("#{File.dirname(__FILE__)}/../deployment.yml")
+
+DEPLOY_ENV = ENV.fetch("RACK_ENV", "staging")
+
+settings = settings["common"].merge(settings[DEPLOY_ENV])
+
+INSTANCES  = settings["instances"]
+BASE_PORT  = settings["base_port"]
+APP_NAME   = settings["name"]
+IMAGE_NAME = "#{APP_NAME}:#{DEPLOY_ENV}"
+
+begin
+    puts "Building Image for #{DEPLOY_ENV} (#{IMAGE_NAME})"
+   `docker build -f Dockerfile.#{DEPLOY_ENV} -t #{IMAGE_NAME} .`
+rescue => e
+    puts "Image build failed: #{e.message}"
+    exit 1
+end
+
+begin
+    puts "Creating / Replacing containers"
+    INSTANCES.times do |t|
+      container_name = "fwc_#{DEPLOY_ENV}_#{t+1}"
+      port = BASE_PORT + t
+
+      puts "Removing #{container_name}"
+      begin
+          `docker container stop #{container_name}`
+      rescue
+          puts "#{container_name} does not exist. Creating..."
+          exit 1
+      end
+      puts "Running #{container_name}"
+
+      running = `docker run -dit -p #{port}:#{settings["container_port"]} --name=#{container_name} --rm --network="#{settings["network"]}" -e RACK_ENV=#{DEPLOY_ENV} -v "$(pwd)"/log:/srv/http/#{APP_NAME}/log -v "$(pwd)"/config:/srv/http/#{APP_NAME}/public -v "$(pwd)"/config:/srv/http/#{APP_NAME}/config #{IMAGE_NAME}`
+      puts running
+     end
+rescue => e
+    puts "Error creating containers"
+    exit 1
+end

--- a/deployment.yml
+++ b/deployment.yml
@@ -1,0 +1,15 @@
+---
+common:
+  name: funkyworldcup.com
+  instances: 2
+  network: 3fm
+  base_port: 3000
+  container_port: 8080
+
+production:
+  instances: 3
+  base_port: 5100
+
+staging:
+  base_port: 5000
+  network: fwc


### PR DESCRIPTION
This PR adds the necessary files for the deployment.

The `bin/deploy` script will be run by the corresponding git hook together with the corresponding `RACK_ENV` env var setting.

This script will make use of the `Dockerfile.staging` or `Dockerfile.production` to build the image and run the corresponding containers. Currently these two files are identical, but they might differ in the future, so I'd like to keep them separated by environment.

Some settings can be different for the staging and production environments, for example, the amount of running containers, and the local ports that are mapped to the container's ports. These settings are specified in the `deployment.yml` file, separated per environment and will be loaded dynamically by the `bin/deploy` script