### PR TITLE
Set default participant img on error

### DIFF
--- a/views/groups/_participants.html.erb
+++ b/views/groups/_participants.html.erb
@@ -18,11 +18,7 @@
             <td>#<%= key %></td>
             <td><%=participant[:score] || 0 %></td>
             <td>
-              <% if participant[:image] %>
-                <img src="<%= participant[:image] %>" class="participant-img">
-              <% else %>
-                <img src="/img/soccer-ball.svg" class="participant-img">
-              <% end %>
+              <%= partial("shared/_participant_img.html", image: participant[:image], classes: []) %>
               <span><%= participant[:nickname] %></span>
             </td>
             <td class="text-right">

--- a/views/groups/_participants_popup.html.erb
+++ b/views/groups/_participants_popup.html.erb
@@ -22,11 +22,7 @@
                 <td>#<%= key %></td>
                 <td><%=participant[:score] || 0 %></td>
                 <td>
-                  <% if participant[:image] %>
-                    <img src="<%= participant[:image] %>" class="participant-img">
-                  <% else %>
-                    <img src="/img/soccer-ball.svg" class="participant-img">
-                  <% end %>
+                  <%= partial("shared/_participant_img.html", image: participant[:image], classes: []) %>
                   <span><%= participant[:nickname] %></span>
                 </td>
               </tr>

--- a/views/pages/rank.html.erb
+++ b/views/pages/rank.html.erb
@@ -32,11 +32,11 @@
                   <td>
                     <% if FunkyWorldCup.finalized? %>
                       <a href="/users/<%= rank.user.id %>/predictions">
-                        <img src="<%= rank.user.image %>" class="participant-img d-none d-sm-inline d-md-inline">
+                        <%= partial("shared/_participant_img.html", image: rank.user.image, classes: ["d-none", "d-sm-inline"]) %>
                         <%= rank.user.nickname %>
                       </a>
                     <% else %>
-                      <img src="<%= rank.user.image %>" class="participant-img d-none d-sm-inline d-md-inline">
+                      <%= partial("shared/_participant_img.html", image: rank.user.image, classes: ["d-none", "d-sm-inline"]) %>
                       <%= rank.user.nickname %>
                     <% end %>
                   </td>

--- a/views/shared/_participant_img.html.erb
+++ b/views/shared/_participant_img.html.erb
@@ -1,0 +1,4 @@
+<img src="<%= image %>"
+     class="participant-img <%= classes.join(" ") %>"
+     onerror="this.src='/img/soccer-ball.svg'"
+>


### PR DESCRIPTION
This PR creates a new partial for participant image. If the img can't be load, it will trigger an `onerror` event.

The event handler must be attached before the browser fires the event so it's not possible to use `$('.participant-img').on("error", handler)` (because it will be attaching the handler when the img tag is already rendered)