### PR TITLE
Add application tips in fixture page

### DIFF
--- a/locale/en/predictions.yml
+++ b/locale/en/predictions.yml
@@ -13,4 +13,6 @@ en:
       in_progress: In Progress
       finished: Finished
     no_predictions: You didn't make any prediction yet. Please check your <a href="/dashboard">Dashboard</a> or the <a href="/cup-groups/fixture">Fixture</a> and make your predictions
-
+    tips:
+      noedit: Check your prediction twice! Once confirmed you will not be able to change it.
+      norush: You are not required to add all predictions at once! You will be able to predict a match minutes before it starts.

--- a/locale/es/predictions.yml
+++ b/locale/es/predictions.yml
@@ -13,3 +13,6 @@ es:
       in_progress: Comenzado
       finished: Finalizado
     no_predictions: No has arriesgado ningún resultado aun. Revisa tu <a href="/dashboard">Panel</a> o el <a href="/cup-groups/fixture">Fixture</a> y comienza ahora!
+    tips:
+      noedit: Revisa tu resultado antes de confirmarlo! No podrás cambiarlo una vez que lo confirmes.
+      norush: No es necesario que arriesgues todos los resultados ahora! Podrás agregar tu predicción hasta minutos antes del partido.

--- a/views/cup_groups/_fixture_notifications.html.erb
+++ b/views/cup_groups/_fixture_notifications.html.erb
@@ -1,0 +1,41 @@
+<div class="alert alert-primary alert-with-icon dashboard-alert fixture-notification d-none" data-notify="container" id="fixture-noedit-prediction">
+  <button type="button" aria-hidden="true" class="close" data-dismiss="alert">
+    <i class="nc-icon nc-simple-remove"></i>
+  </button>
+  <span data-notify="icon" class="nc-icon nc-bulb-63"></span>
+  <span data-notify="message">
+    <%= I18n.t(".predictions.tips.norush") %>
+  </span>
+</div>
+
+<div class="alert alert-primary alert-with-icon dashboard-alert fixture-notification d-none" data-notify="container" id="fixture-beforematch-prediction">
+  <button type="button" aria-hidden="true" class="close" data-dismiss="alert">
+    <i class="nc-icon nc-simple-remove"></i>
+  </button>
+  <span data-notify="icon" class="nc-icon nc-bulb-63"></span>
+  <span data-notify="message">
+    <%= I18n.t(".predictions.tips.noedit") %>
+  </span>
+</div>
+
+<% content_for :javascripts do %>
+  <script type="text/javascript">
+    var storage = window.localStorage;
+
+    if (storage) {
+      $(".fixture-notification").each( function () {
+        var _this = $(this);
+        var id = _this.attr("id");
+
+        var local_storage_value = storage.getItem(id);
+
+        if (!local_storage_value) {
+          _this.on("close.bs.alert", function () {
+            storage.setItem(id, true);
+          });
+          _this.removeClass("d-none");
+        }
+      })
+    }
+  </script>
+<% end %>

--- a/views/cup_groups/fixture.html.erb
+++ b/views/cup_groups/fixture.html.erb
@@ -1,5 +1,7 @@
 <% content_for(:title){ I18n.t('.common.fixture') } %>
 
+<%= partial("cup_groups/_fixture_notifications.html") %>
+
 <div class="row">
   <% groups.each do |group_name, matches| %>
     <div class="col-xl-6 col-lg-12">


### PR DESCRIPTION
This PR adds two notifications in fixture page:

![tips](https://user-images.githubusercontent.com/357127/40715264-5dcd426e-63db-11e8-8c08-21664dc17607.png)

If the user dismisses any of the notifications, the application will use `localStorage` to hide it the next time.