### PR TITLE
New scores api for results update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ public/css/funky_world_cup.css
 public/css/funky_world_cup.css.map
 public/css/funky_world_cup_light.css
 public/css/funky_world_cup_light.css.map
+.gemsetrc

--- a/app.rb
+++ b/app.rb
@@ -11,7 +11,7 @@ require 'sass/plugin/rack'
 
 require_relative 'helpers/environment'
 
-ENV['RACK_ENV'] ||= :development
+ENV['RACK_ENV'] ||= "development"
 
 I18n.load_path += Dir['./locale/**/*.yml']
 Encoding.default_internal, Encoding.default_external = ['utf-8'] * 2

--- a/env.sh.sample
+++ b/env.sh.sample
@@ -10,3 +10,5 @@ FWC_URL=https://funkyworldcup.com/
 SESSION_SECRET=[Your value]
 ANALYTICS_ID=[Your value]
 DONATE_ENCRIPTED=[Your value]
+LIVESCORE_API_KEY=[Your value]
+LIVESCORE_API_SECRET=[Your value]

--- a/jobs/update_results.rb
+++ b/jobs/update_results.rb
@@ -105,6 +105,9 @@ class UpdateResultsJob < BaseJob
   end
 
   def self.notify(match, match_status)
+    host_hashtag = "##{match.host_team.name.gsub(" ", "")}"
+    rival_hashtag = "##{match.rival_team.name.gsub(" ", "")}"
+
     status = ["#{match.host_team.name} #{match.result.host_score}"]
     status << "#{match.result.rival_score} #{match.rival_team.name}"
 
@@ -117,7 +120,7 @@ class UpdateResultsJob < BaseJob
       status << "End"
     end
 
-    notification = "#{status.join(" - ")} #BR2014 #Results #Resultados"
+    notification = "#{status.join(" - ")} #RU2018 #Results #Resultados #{host_hashtag} #{rival_hashtag} #WorldCup"
 
     @@tw_notifier.notify(notification)
   end

--- a/jobs/update_results.rb
+++ b/jobs/update_results.rb
@@ -1,7 +1,6 @@
 require 'eventmachine'
 require 'logger'
 require 'net/http'
-require 'nokogiri'
 require './lib/twitter_notifier'
 require "./app"
 

--- a/models/match.rb
+++ b/models/match.rb
@@ -97,7 +97,7 @@ class Match < Sequel::Model
   end
 
   def self.today_matches
-    Match.where("DATE(start_datetime) BETWEEN ?  AND ?",  Date.today - 1, Date.today + 1)
+    Match.where(Sequel.lit("DATE(start_datetime) BETWEEN ?  AND ?"),  Date.today - 1, Date.today + 1)
   end
 
   def self.for_team(iso_code)


### PR DESCRIPTION
This PR uses the [Livescore API](http://livescore-api.com) to fetch live results and update the matches results accordingly.

Penalties updates are still to be resolved because there's no visible information about how the API will provide those results.

I'll continue the research and try to contact support from Livescore API.

Close #156 