### PR TITLE
Log users last seen moment

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -22,6 +22,10 @@ rescue => e
 end
 
 begin
+    puts "Running migrations"
+
+    `docker run -it --rm --network="#{settings["network"]}" -e FLASK_ENV=#{DEPLOY_ENV} #{IMAGE_NAME} rake db migrate`
+
     puts "Creating / Replacing containers"
     INSTANCES.times do |t|
       container_name = "fwc_#{DEPLOY_ENV}_#{t+1}"

--- a/db/migrate/021_add_user_last_seen.rb
+++ b/db/migrate/021_add_user_last_seen.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  up do
+    alter_table(:users) do
+      add_column :last_seen, "integer"
+    end
+  end
+
+  down do
+    drop_column :users, :last_seen
+  end
+end

--- a/models/user.rb
+++ b/models/user.rb
@@ -24,4 +24,8 @@ class User < Sequel::Model
     notifications.update(read: true)
     user_notifications
   end
+
+  def checkin
+    self.update(last_seen: Time.now.to_i)
+  end
 end

--- a/routes/main.rb
+++ b/routes/main.rb
@@ -54,6 +54,9 @@ module FunkyWorldCup
 
             map_hash = FunkyWorldCup::Map.new(CupGroup.all).series_data
 
+            # refresh last seen
+            current_user.checkin
+
             res.write view("pages/dashboard.html",
               matches:      matches,
               winners:      winners,


### PR DESCRIPTION
This PR adds a field to the users table in order to track the last time the user was seen on the dashboard with the purpose of detect active users.

This could be useful to filter out inactive users from the ranking page, for example.

This is just a random idea I've had on my mind for a few days, but it could totally discarded if it's proven not useful.

@tarolandia thoughts?
